### PR TITLE
Fixed incorrect context in docker-compose file for web

### DIFF
--- a/docker-compose.web.yml
+++ b/docker-compose.web.yml
@@ -4,7 +4,7 @@ services:
     image: "marquezproject/marquez-web:${TAG}"
     container_name: marquez-web
     build:
-      context: .
+      context: web
       args:
         REACT_APP_ADVANCED_SEARCH: ${SEARCH_ENABLED}
     environment:


### PR DESCRIPTION
### Problem

Wrong context is being used to build the marquez-web container. It should be using the the Docker file inside the web folder.

### Solution
Updated the build-> context to web folder so that docker compose picks up the correct Docker file.

One-line summary: Updated the build-> context to web folder so that docker compose picks up the correct Docker file.

### Checklist

- [ x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
